### PR TITLE
Set pipeline timeout to 0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,8 @@ stages:
 
     jobs:
       - job: Scan
+        timeoutInMinutes: 0
+
         pool:
           vmImage: 'ubuntu-latest'
 


### PR DESCRIPTION
According to the [documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts), these are the default timeouts:

- No time limit on self-hosted agents
- 360 minutes (6 hours) on Microsoft-hosted agents with a public project and public repository
- 60 minutes on Microsoft-hosted agents with a private project or private repository (unless you pay for additional capacity)

This adjustment sets the timeoutInMinutes to 0, allowing the pipeline to run using the maximum limit available (described above).