### PR TITLE
Fix repository cloning failures by disabling Git symlinks

### DIFF
--- a/scan_azure_devops_secret.sh
+++ b/scan_azure_devops_secret.sh
@@ -51,6 +51,8 @@ if [ ! -z "$GIT_USER_NAME" ] || [ ! -z "$GIT_USER_NAME" ]; then
   echo "Enable scripts to run Git commands for user.email $GIT_USER_EMAIL and user.name $GIT_USER_NAME"
   git config --global user.email "$GIT_USER_EMAIL"
   git config --global user.name "$GIT_USER_NAME"
+  echo "Disable support for symbolic links"
+  git config --global core.symlinks false
 else
   echo "Git user.email and user.name will use the current setting"
 fi


### PR DESCRIPTION
## Problem
The cleanup script was failing with the following error when attempting to clone specific repositories:
```
error: unable to create symlink Clean-Repos.ps1: File name too long
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
```

After investigation, the root cause was identified: Some repositories contain files that were originally symlinks but had their content modified without properly changing their mode from symlink to regular file. This created Git blob objects that are marked as symlinks but contain content too long to be valid pathnames, making them impossible to extract on systems that support real symlinks.

## Solution
Added the following Git configuration to the script:
```bash
git config --global core.symlinks false
```

This configuration forces Git to treat all files as regular files during clone operations, bypassing the symlink-related errors and allowing successful repository scanning. [^1]

## Security Considerations
This change does not impact the security scanning effectiveness:
- For symlinks pointing outside the repository: These external files were never accessible for scanning anyway
- For symlinks pointing inside the repository: The target files are still scanned directly, ensuring no vulnerabilities are missed

## Testing
- Verified successful cloning of repositories that previously failed due to invalid symlink objects
- Confirmed that security scanning processes all relevant files
- Tested on Ubuntu environment where the issue was originally encountered

[^1]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresymlinks
